### PR TITLE
feat: public url and customized role names

### DIFF
--- a/.env
+++ b/.env
@@ -9,3 +9,4 @@ SUBSCRIBERS_GROUP_ID=4
 LIFETIME_ROLE_NAME=Lifetime
 LIFETIME_GROUP_ID=5
 SERVICE_NAME=YourServiceName
+PUBLIC_URL=https://authelia.yoursite.com

--- a/.env
+++ b/.env
@@ -9,4 +9,4 @@ SUBSCRIBERS_GROUP_ID=4
 LIFETIME_ROLE_NAME=Lifetime
 LIFETIME_GROUP_ID=5
 SERVICE_NAME=YourServiceName
-PUBLIC_URL=https://authelia.yoursite.com
+PUBLIC_URL=https://authelia.yoursite.com # Optional if LLDAP is not frontend

--- a/README.md
+++ b/README.md
@@ -24,8 +24,11 @@ SUBSCRIBERS_GROUP_ID=4
 LIFETIME_ROLE_NAME=Lifetime
 LIFETIME_GROUP_ID=5
 SERVICE_NAME=YourServiceName
+PUBLIC_URL=(Optional) The public facing URL of your auth system (ex: authelia)
 ```
 
+Note that `PUBLIC_URL` is not required and will default to the value of `LLDAP_LOGIN_URL` if not set. This makes it easy to integrate the bot with a different authentication frontend, such as Authentik or Authelia.
+Additionally, the `SUBSCRIBER_ROLE_NAME` and `LIFETIME_ROLE_NAME` are customizable, and the messages the bot sends will automatically update based on these values. An example use case is if you wanted to use the bot to assign service admins based on discord roles. The bot is also able to assign multiple roles to a single user.
 
 ## Docker Install
 

--- a/README.md
+++ b/README.md
@@ -55,6 +55,7 @@ services:
       - LIFETIME_ROLE_NAME=Lifetime
       - LIFETIME_GROUP_ID=5
       - SERVICE_NAME=YourServiceName
+      - PUBLIC_URL=https://authelia.yourdomain.com (OPTIONAL)
 ```
 
 

--- a/discord_bot.py
+++ b/discord_bot.py
@@ -19,10 +19,12 @@ class DiscordBot:
         self.user_manager = subscriptions_sync.user_manager
         self.lldap_login_url = None
         self.service_name = service_name
+        self.public_url = None
 
-    async def start(self, lldap_login_url):
+    async def start(self, lldap_login_url, public_url):
         """Starts the Discord bot within the existing event loop."""
         self.lldap_login_url = lldap_login_url
+        self.public_url = public_url
         self.setup_commands()
         self.bot.event(self.on_ready)
         await self.bot.start(self.token)
@@ -87,7 +89,7 @@ class DiscordBot:
             return
 
         # Determine account type message based on roles
-        account_type = "Lifetime" if has_lifetime else "Subscriber"
+        account_type = self.lifetime_role_name if has_lifetime else self.subscriber_role_name
         
         # Create user in LLDAP with appropriate group assignments
         temp_password, error = await self.user_manager.create_user(
@@ -100,7 +102,7 @@ class DiscordBot:
         if temp_password:
             await interaction.response.send_message(
                 f":white_check_mark: **__{self.service_name} {account_type} Account Created!__**\n\n"
-                f"__**Use this link to log in and change your password:**__ {self.lldap_login_url}\n\n"
+                f"__**Use this link to log in and change your password:**__ {self.public_url}\n\n"
                 f"**Username**: `{chosen_username}`\n"
                 f"**Temporary Password**: `{temp_password}`",
                 ephemeral=True

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -19,3 +19,4 @@ services:
       - LIFETIME_ROLE_NAME=Lifetime
       - LIFETIME_GROUP_ID=5
       - SERVICE_NAME=YourServiceName
+      - PUBLIC_URL=https://authelia.yourdomain.com (OPTIONAL)

--- a/environment_config.py
+++ b/environment_config.py
@@ -16,7 +16,7 @@ class EnvironmentConfig:
         self.subscribers_group_id = int(os.getenv("SUBSCRIBERS_GROUP_ID"))
         self.lifetime_role_name = os.getenv("LIFETIME_ROLE_NAME")
         self.lifetime_group_id = int(os.getenv("LIFETIME_GROUP_ID"))
-        self.service_name = os.getenv("SERVICE_NAME") or "Slothflix" # Default to "Slothflix" if not set
+        self.service_name = os.getenv("SERVICE_NAME")
         self.public_url = os.getenv("PUBLIC_URL") or os.getenv("LLDAP_LOGIN_URL") # Default to 'lldap_login_url' if not set
 
     def get_ldap_username(self):

--- a/environment_config.py
+++ b/environment_config.py
@@ -16,7 +16,8 @@ class EnvironmentConfig:
         self.subscribers_group_id = int(os.getenv("SUBSCRIBERS_GROUP_ID"))
         self.lifetime_role_name = os.getenv("LIFETIME_ROLE_NAME")
         self.lifetime_group_id = int(os.getenv("LIFETIME_GROUP_ID"))
-        self.service_name = os.getenv("SERVICE_NAME")  # Default to "Slothflix" if not set
+        self.service_name = os.getenv("SERVICE_NAME") or "Slothflix" # Default to "Slothflix" if not set
+        self.public_url = os.getenv("PUBLIC_URL") or os.getenv("LLDAP_LOGIN_URL") # Default to 'lldap_login_url' if not set
 
     def get_ldap_username(self):
         """Extracts the username from LDAP_BIND_DN (e.g., 'uid=admin,ou=people,dc=example,dc=com' → 'admin')."""

--- a/main.py
+++ b/main.py
@@ -51,7 +51,7 @@ async def main():
 
     # Start the bot within the same event loop
     try:
-        await bot.start(config.lldap_login_url)
+        await bot.start(config.lldap_login_url, config.public_url)
     finally:
         await auth_manager.close()  # Clean up AuthManager session
 


### PR DESCRIPTION
Hello again,

this is a cherry picked version of a customization feature. this will use the provided discord role names in the messages about the functions bot does, without modifying backend variables. this also includes a feature to allow a public facing auth page in the event that lldap is used as a backend and is not user facing.

i cherrypicked these in the event you would rather not merge #2 , but if you do i can easily rebase.

Also, while I have you, have you considered adding a LICENSE file to the repository? as it is this code exists in a dubious state of being FOSS, as you still retain all rights and copyrights. there's a chance my fork could be a bad thing for instance.

MIT is an option if you don't really care about getting source code back or how the project is used and just want to be credited, while GPL would require people to contribute back to you.

thanks for your time,

yuki