### PR TITLE
Use extended operation to update password

### DIFF
--- a/ldap_manager.py
+++ b/ldap_manager.py
@@ -2,7 +2,7 @@ from ldap3 import Server, Connection, ALL, MODIFY_REPLACE
 
 class LDAPManager:
     """Handles LDAP operations, such as setting user passwords."""
-    
+
     def __init__(self, server_url, bind_dn, bind_password):
         self.server_url = server_url
         self.bind_dn = bind_dn
@@ -14,7 +14,11 @@ class LDAPManager:
             server = Server(self.server_url, get_info=ALL)
             conn = Connection(server, self.bind_dn, self.bind_password, auto_bind=True)
 
-            conn.modify(user_dn, {'userPassword': [(MODIFY_REPLACE, [new_password])]})
+            conn.extend.standard.modify_password(
+                user=user_dn,
+                old_password='',
+                new_password=new_password
+            )
 
             if conn.result['description'] == 'success':
                 print(f"✅ Password set successfully for {user_dn}")


### PR DESCRIPTION
LLDAP requires [1](https://github.com/lldap/lldap/issues/1089)[2](https://github.com/lldap/lldap/issues/573) the use of the standard [RFC 3062](https://datatracker.ietf.org/doc/html/rfc3062) ['modify password'](https://ldap3.readthedocs.io/en/latest/standard.html) extended operation.

Without this change, I was seeing user accounts being created, but the temporary password not being set.

The LDAP3 docs seem to imply that you can omit the `new_password` named arg, but I wasn't able to get a successful response from LLDAP without it.